### PR TITLE
ci: Add Build and Push container image workflow

### DIFF
--- a/.github/workflows/build-and-push-main.yml
+++ b/.github/workflows/build-and-push-main.yml
@@ -1,0 +1,37 @@
+name: Build and push main container image
+
+on:
+  push:
+    branches:
+      - main
+      - ci/image_build_push
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Dev Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/exalsius/exalsius-operator:main

--- a/.github/workflows/build-and-push-main.yml
+++ b/.github/workflows/build-and-push-main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci/image_build_push
 
 permissions:
   contents: read

--- a/charts/exalsius-operator/charts/operator/values.yaml
+++ b/charts/exalsius-operator/charts/operator/values.yaml
@@ -1,9 +1,9 @@
 replicaCount: 1
 
 image:
-  repository: srnbckr/exalsius-operator
+  repository: ghcr.io/exalsius/exalsius-operator
   pullPolicy: Always
-  tag: "latest"
+  tag: "main"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
**Description**

This PR adds a GitHub worklow to build and push the operator image to the GHCR container registry.

**Notes for Reviewers**
The image can be pulled with e.g.

```
docker pull ghcr.io/exalsius/exalsius-operator:main
```
<!--
Thank you for contributing to exalsius! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Ensure correct formatting of your code by e.g. installing the pre-commit-hooks.
-->
