### PR TITLE
fix[helm]: Add externalAdress as a possible field for hosted control plane deployments

### DIFF
--- a/api/infra/v1/colony_types.go
+++ b/api/infra/v1/colony_types.go
@@ -43,6 +43,11 @@ type ColonySpec struct {
 	// If this is not set, the colony will create a control plane in the colony cluster.
 	// +optional
 	HostedControlPlaneEnabled *bool `json:"hostedControlPlaneEnabled,omitempty"`
+	// ExternalAddress is the external address of the colony cluster.
+	// This is used to set the external address of the control plane.
+	// If this is not set, the colony will try to find an external address for the control plane.
+	// +optional
+	ExternalAddress *string `json:"externalAddress,omitempty"`
 
 	// ColonyClusters is the list of clusters to create.
 	ColonyClusters []ColonyCluster `json:"colonyClusters,omitempty"`

--- a/api/infra/v1/zz_generated.deepcopy.go
+++ b/api/infra/v1/zz_generated.deepcopy.go
@@ -193,6 +193,11 @@ func (in *ColonySpec) DeepCopyInto(out *ColonySpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ExternalAddress != nil {
+		in, out := &in.ExternalAddress, &out.ExternalAddress
+		*out = new(string)
+		**out = **in
+	}
 	if in.ColonyClusters != nil {
 		in, out := &in.ColonyClusters, &out.ColonyClusters
 		*out = make([]ColonyCluster, len(*in))

--- a/charts/exalsius-operator/charts/operator/crds/infra.exalsius.ai_colonies.yaml
+++ b/charts/exalsius-operator/charts/operator/crds/infra.exalsius.ai_colonies.yaml
@@ -422,6 +422,12 @@ spec:
                   - clusterName
                   type: object
                 type: array
+              externalAddress:
+                description: |-
+                  ExternalAddress is the external address of the colony cluster.
+                  This is used to set the external address of the control plane.
+                  If this is not set, the colony will try to find an external address for the control plane.
+                type: string
               hostedControlPlaneEnabled:
                 description: |-
                   HostedControlPlaneEnabled indicates if the hosted control plane is enabled.

--- a/config/crd/bases/infra.exalsius.ai_colonies.yaml
+++ b/config/crd/bases/infra.exalsius.ai_colonies.yaml
@@ -422,6 +422,12 @@ spec:
                   - clusterName
                   type: object
                 type: array
+              externalAddress:
+                description: |-
+                  ExternalAddress is the external address of the colony cluster.
+                  This is used to set the external address of the control plane.
+                  If this is not set, the colony will try to find an external address for the control plane.
+                type: string
               hostedControlPlaneEnabled:
                 description: |-
                   HostedControlPlaneEnabled indicates if the hosted control plane is enabled.

--- a/examples/remote-colony.yaml
+++ b/examples/remote-colony.yaml
@@ -7,7 +7,11 @@ spec:
   workloadDependencies:
     - name: volcano-sh
 
-  hostedControlPlaneEnabled: true 
+  hostedControlPlaneEnabled: true
+  # In case the nodes of the management cluster have the external IP not set,
+  # you can set the external address here.
+  # This is used for hosted control planes as the API Server NodePort IP.
+  externalAddress: "192.168.1.100"
 
   colonyClusters:
     - clusterName: remote-1


### PR DESCRIPTION
**Description**

This PR fixes a bug when the external address of node of the management cluster is not set. In that case, the hosted k0smotron control plane can't be reached from the outside, since the API server certificate is only valid for a private IP.

It adds an optional field `externalAdress` to the Colony CRD that can be used to manually set an external address for the created NodePorts. If it is not set, the operator tries to automatically guess the external IP by checking the available node addresses.


**Notes for Reviewers**


<!--
Thank you for contributing to exalsius! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Ensure correct formatting of your code by e.g. installing the pre-commit-hooks.
-->
