### PR TITLE
fix[docker-colony]: Add fixed NodePort/API port for local docker colony clusters

### DIFF
--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -13,3 +13,9 @@ nodes:
       - containerPort: 30051
         hostPort: 30051
         protocol: TCP
+      - containerPort: 30333
+        hostPort: 30333
+        protocol: TCP
+      - containerPort: 30334
+        hostPort: 30334
+        protocol: TCP

--- a/internal/controller/infra/controlplane/k0smotron.go
+++ b/internal/controller/infra/controlplane/k0smotron.go
@@ -34,6 +34,19 @@ func EnsureK0smotronControlPlane(ctx context.Context, c client.Client, colony *i
 		if err != nil {
 			return fmt.Errorf("failed to get external address: %w", err)
 		}
+
+		// edge-case: a local docker cluster needs to have a static nodePort
+		// so that kind-based port-forwarding works
+		// TODO: this currently only works for a single docker cluster
+		for _, cluster := range colony.Spec.ColonyClusters {
+			if cluster.DockerEnabled != nil && *cluster.DockerEnabled {
+				externalAddress = ""
+				apiPort = 30333
+				konnectivityPort = 30334
+				break
+			}
+		}
+
 	}
 
 	k0smotronControlPlane := &k0sv1beta1.K0smotronControlPlane{


### PR DESCRIPTION
**Description**

This PR adds a fixed NodePort forward for local docker colony clusters, so that they can be reached via e.g. kubectl.

**Notes for Reviewers**


<!--
Thank you for contributing to exalsius! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Ensure correct formatting of your code by e.g. installing the pre-commit-hooks.
-->
