### PR TITLE
ci: move comment in PR template to the bottom

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+## Description
+
+This PR fixes #
+
+## Notes for Reviewers
+
 <!-- 
 ## PR Title Format (Conventional Commits)
 
@@ -30,9 +36,3 @@ Co-authored-by: Bob <bob@example.com>
 
 More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 -->
-
-## Description
-
-This PR fixes #
-
-## Notes for Reviewers

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,11 +1,12 @@
-name: Test Chart Deployment
+name: Release PR - Pre-Release E2E Tests
 
 on:
   pull_request:
+    branches: [main]
 
 jobs:
-  test-e2e:
-    name: Run on Ubuntu
+  test-helm:
+    if: startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code


### PR DESCRIPTION

## Description

This PR moves the long comment in the pull request template to the bottom.

## Notes for Reviewers