### PR TITLE
ci: increase ulimit and max_user_watches/instances before running helm

### DIFF
--- a/hack/install-ci.sh
+++ b/hack/install-ci.sh
@@ -21,6 +21,20 @@ if [ -n "$VALUES_FILE" ]; then
     echo "Using values file for exalsius-operator: $VALUES_FILE"
 fi
 
+# set ulimit and sysctls
+ulimit -n 65535
+if command -v sudo >/dev/null && sudo -n true 2>/dev/null; then
+  echo "Running sysctl updates with sudo"
+  sudo sysctl -w fs.inotify.max_user_watches=524288
+  sudo sysctl -w fs.inotify.max_user_instances=8192
+else
+  echo "[WARNING] Skipping sysctl updates (no sudo permissions)"
+  echo "Consider setting the following sysctls manually:"
+  echo "sysctl -w fs.inotify.max_user_watches=524288"
+  echo "sysctl -w fs.inotify.max_user_instances=8192"
+  echo "ulimit -n 65535"
+fi
+
 # install cert manager
 echo "installing cert-manager"
 
@@ -31,7 +45,6 @@ helm upgrade --install cert-manager \
   --create-namespace \
   --set crds.enabled=true \
   --wait
-
 
 # install volcano
 echo "installing volcano"

--- a/hack/install-via-helm.sh
+++ b/hack/install-via-helm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 NAMESPACE=exalsius-system
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -19,6 +21,20 @@ fi
 # print path to values file if set
 if [ -n "$VALUES_FILE" ]; then
     echo "Using values file for exalsius-operator: $VALUES_FILE"
+fi
+
+# set ulimit and sysctls
+ulimit -n 65535
+if command -v sudo >/dev/null && sudo -n true 2>/dev/null; then
+  echo "Running sysctl updates with sudo"
+  sudo sysctl -w fs.inotify.max_user_watches=524288
+  sudo sysctl -w fs.inotify.max_user_instances=8192
+else
+  echo "[WARNING] Skipping sysctl updates (no sudo permissions)"
+  echo "Consider setting the following sysctls manually:"
+  echo "sysctl -w fs.inotify.max_user_watches=524288"
+  echo "sysctl -w fs.inotify.max_user_instances=8192"
+  echo "ulimit -n 65535"
 fi
 
 # install cert manager


### PR DESCRIPTION
## Description

This PR fixes #33 by increasing the ulimit, fs.inotify.max_user_watches and fs.inotify.max_user_instances values.

## Notes for Reviewers
Changing the values requires sudo permissions, which are automatically checked in the install scripts.

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->