### PR TITLE
fix: add --debug flag to helm install commands

### DIFF
--- a/hack/install-ci.sh
+++ b/hack/install-ci.sh
@@ -21,6 +21,20 @@ if [ -n "$VALUES_FILE" ]; then
     echo "Using values file for exalsius-operator: $VALUES_FILE"
 fi
 
+# set ulimit and sysctls
+ulimit -n 65535
+if command -v sudo >/dev/null && sudo -n true 2>/dev/null; then
+  echo "Running sysctl updates with sudo"
+  sudo sysctl -w fs.inotify.max_user_watches=524288
+  sudo sysctl -w fs.inotify.max_user_instances=8192
+else
+  echo "[WARNING] Skipping sysctl updates (no sudo permissions)"
+  echo "Consider setting the following sysctls manually:"
+  echo "sysctl -w fs.inotify.max_user_watches=524288"
+  echo "sysctl -w fs.inotify.max_user_instances=8192"
+  echo "ulimit -n 65535"
+fi
+
 # install cert manager
 echo "installing cert-manager"
 
@@ -31,7 +45,6 @@ helm upgrade --install cert-manager \
   --create-namespace \
   --set crds.enabled=true \
   --wait
-
 
 # install volcano
 echo "installing volcano"

--- a/hack/install-ci.sh
+++ b/hack/install-ci.sh
@@ -44,7 +44,8 @@ helm upgrade --install cert-manager \
   --namespace cert-manager \
   --create-namespace \
   --set crds.enabled=true \
-  --wait
+  --wait \
+  --debug
 
 # install volcano
 echo "installing volcano"
@@ -52,7 +53,8 @@ helm repo add volcano-sh https://volcano-sh.github.io/helm-charts
 helm upgrade --install volcano volcano-sh/volcano \
   --namespace volcano-system \
   --create-namespace \
-  --wait
+  --wait \
+  --debug
 
 echo "installing cluster-api operator"
 # install cluster-api-provider
@@ -60,7 +62,8 @@ helm repo add capi-operator https://kubernetes-sigs.github.io/cluster-api-operat
 helm install capi-operator capi-operator/cluster-api-operator \
   --create-namespace \
   --namespace capi-system \
-  --wait
+  --wait \
+  --debug
 
 echo "installing exalsius-operator umbrella chart"
 helm dependency update "${SCRIPT_DIR}/../charts/exalsius-operator"
@@ -69,4 +72,5 @@ helm upgrade --install exalsius "${SCRIPT_DIR}/../charts/exalsius-operator" \
   --create-namespace \
   $VALUES_ARG \
   --wait \
-  --timeout 30m
+  --timeout 30m \
+  --debug

--- a/hack/install-via-helm.sh
+++ b/hack/install-via-helm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 NAMESPACE=exalsius-system
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -19,6 +21,20 @@ fi
 # print path to values file if set
 if [ -n "$VALUES_FILE" ]; then
     echo "Using values file for exalsius-operator: $VALUES_FILE"
+fi
+
+# set ulimit and sysctls
+ulimit -n 65535
+if command -v sudo >/dev/null && sudo -n true 2>/dev/null; then
+  echo "Running sysctl updates with sudo"
+  sudo sysctl -w fs.inotify.max_user_watches=524288
+  sudo sysctl -w fs.inotify.max_user_instances=8192
+else
+  echo "[WARNING] Skipping sysctl updates (no sudo permissions)"
+  echo "Consider setting the following sysctls manually:"
+  echo "sysctl -w fs.inotify.max_user_watches=524288"
+  echo "sysctl -w fs.inotify.max_user_instances=8192"
+  echo "ulimit -n 65535"
 fi
 
 # install cert manager


### PR DESCRIPTION
## Description

This PR adds the --debug flag to the helm install commands in the E2E test github action.

## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->