### PR TITLE
fix: adjust AWS clusters to work with hosted control planes

### DIFF
--- a/charts/exalsius-operator/templates/k0smotron-providers.yaml
+++ b/charts/exalsius-operator/templates/k0smotron-providers.yaml
@@ -9,7 +9,12 @@ metadata:
  #  helm.sh/hook-weight: "10"
 spec:
  version: {{ .Values.capi.k0smotron_control_plane_provider_version }}
-
+ deployment:
+    containers:
+    - name: manager
+      resources:
+        limits:
+          memory: 512Mi
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: BootstrapProvider

--- a/charts/exalsius-operator/values.yaml
+++ b/charts/exalsius-operator/values.yaml
@@ -5,11 +5,11 @@ operator:
 
 
 capi:
-  core_provider_version: v1.9.5
-  k0smotron_control_plane_provider_version: v1.4.3
-  k0smotron_bootstrap_provider_version: v1.4.3
-  k0smotron_infrastructure_provider_version: v1.4.3
-  aws_provider_version: v2.7.1
+  core_provider_version: v1.9.6
+  k0smotron_control_plane_provider_version: v1.5.1
+  k0smotron_bootstrap_provider_version: v1.5.1
+  k0smotron_infrastructure_provider_version: v1.5.1
+  aws_provider_version: v2.8.2
   docker_provider_version: v1.4.2
   helm_addon_provider_version: v0.3.1
 

--- a/internal/controller/infra/aws/aws_resources.go
+++ b/internal/controller/infra/aws/aws_resources.go
@@ -60,7 +60,6 @@ func ensureAWSMachineTemplate(ctx context.Context, c client.Client, colony *infr
 		Spec: capav1beta2.AWSMachineTemplateSpec{
 			Template: capav1beta2.AWSMachineTemplateResource{
 				Spec: capav1beta2.AWSMachineSpec{
-					//UncompressedUserData: ptr.To(false),
 					AMI: capav1beta2.AMIReference{
 						ID: &colonyCluster.AWS.AMI,
 					},


### PR DESCRIPTION
## Description

This PR fixes bugs which prevented the usage of hosted control planes with AWS clusters.

## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->