### PR TITLE
ci: remove helm chart publish and fix versioning

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,6 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      helm_tag_name: ${{ steps.release.outputs.helm_tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -25,78 +24,4 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          
-  publish-helm:
-    name: Publish Helm Chart to GHCR
-    needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v4
-
-      - name: Extract versions
-        id: extract_version
-        run: |
-          tag="${{ needs.release-please.outputs.tag_name }}"
-          operator_version="${tag#v}"
-          echo "operator_version=$operator_version" >> "$GITHUB_OUTPUT"
-      
-          helm_tag="${{ needs.release-please.outputs.helm_tag_name }}"
-          if [ -n "$helm_tag" ]; then
-            helm_version="${helm_tag#exalsius-operator-v}"
-            echo "helm_version=$helm_version" >> "$GITHUB_OUTPUT"
-          else
-            echo "Helm chart version not found in release outputs"
-            exit 1
-          fi
-
-      - name: Sync appVersion in Helm Chart
-        run: |
-          version="${{ steps.extract_version.outputs.operator_version }}"
-          chart="charts/exalsius/charts/operator/Chart.yaml"
-          echo "Updating appVersion to: $version"
-          sed -i "s/^appVersion: .*/appVersion: \"$version\"/" "$chart"
-          echo "Updated Chart.yaml appVersion:"
-          grep "^appVersion:" "$chart"
-      
-      - name: Update Helm chart version
-        run: |
-          helm_version="${{ steps.extract_version.outputs.helm_version }}"
-          chart="charts/exalsius/charts/operator/Chart.yaml"
-          echo "Updating chart version to: $helm_version"
-          sed -i "s/^version: .*/version: \"$helm_version\"/" "$chart"
-          echo "Updated Chart.yaml version:"
-          grep "^version:" "$chart"
-
-      - name: Log in to GHCR
-        run: |
-          echo "${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}" | \
-          helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Package Helm chart
-        run: |
-          cd charts/exalsius/charts/operator
-          helm package .
-          ls -lh *.tgz
-
-      - name: Push chart to GHCR
-        run: |
-          cd charts/exalsius/charts/operator
-          helm push exalsius-operator-*.tgz oci://ghcr.io/${{ github.repository_owner }}
-
-      - name: Make chart public on GHCR
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
-        run: |
-          curl -X PATCH https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/exalsius-operator \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -d '{"visibility":"public"}'
 

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,12 +7,6 @@
         "include-component-in-tag": false,
         "bump-minor-pre-major": true,
         "bump-patch-for-minor-pre-major": true
-      },
-      "helm-chart": {
-        "path": "charts/exalsius/charts/operator",
-        "release-type": "helm",
-        "component": "exalsius-operator",
-        "include-component-in-tag": true
       }
     },
     "tag-separator": "v"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,3 @@
 {
-    "go-operator": "0.3.2",
-    "helm-chart": "0.3.0"
+    "go-operator": "0.3.2"
 }


### PR DESCRIPTION
## Description

This PR removes the helm chart publish GitHub action and fixes the operator versioning.

## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->