### PR TITLE
feat: accept optional regional client in EnsureAPIEndpointConfigMap

### DIFF
--- a/internal/controller/infra/cilium/api_endpoint_configmap.go
+++ b/internal/controller/infra/cilium/api_endpoint_configmap.go
@@ -40,6 +40,8 @@ const (
 
 // EnsureAPIEndpointConfigMap creates or updates the cp-api-endpoint ConfigMap in the child cluster
 // with the control plane API server endpoint information.
+// If regionalClient is non-nil, it is used to fetch the kubeconfig secret (for regional children
+// whose kubeconfig lives on the regional cluster rather than the management cluster).
 func EnsureAPIEndpointConfigMap(
 	ctx context.Context,
 	managementClient client.Client,
@@ -47,6 +49,7 @@ func EnsureAPIEndpointConfigMap(
 	clusterName string,
 	exposedEndpoint string,
 	scheme *runtime.Scheme,
+	regionalClient ...client.Client,
 ) error {
 	log := log.FromContext(ctx)
 
@@ -62,8 +65,14 @@ func EnsureAPIEndpointConfigMap(
 		"host", host,
 		"port", port)
 
+	// Determine which client to use for kubeconfig lookup
+	kubeconfigClient := managementClient
+	if len(regionalClient) > 0 && regionalClient[0] != nil {
+		kubeconfigClient = regionalClient[0]
+	}
+
 	// Get client for the child cluster
-	childClient, err := getClientForChildCluster(ctx, managementClient, colony, clusterName, scheme)
+	childClient, err := getClientForChildCluster(ctx, kubeconfigClient, colony, clusterName, scheme)
 	if err != nil {
 		return fmt.Errorf("failed to get client for child cluster: %w", err)
 	}

--- a/internal/controller/infra/cilium/api_endpoint_configmap_test.go
+++ b/internal/controller/infra/cilium/api_endpoint_configmap_test.go
@@ -274,6 +274,135 @@ func TestEnsureAPIEndpointConfigMap(t *testing.T) {
 	}
 }
 
+// TestEnsureAPIEndpointConfigMap_RegionalClient tests the regional client path
+func TestEnsureAPIEndpointConfigMap_RegionalClient(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = infrav1.AddToScheme(scheme)
+
+	tests := []struct {
+		name            string
+		colony          *infrav1.Colony
+		clusterName     string
+		exposedEndpoint string
+		mgmtSetupFunc   func(*fake.ClientBuilder) *fake.ClientBuilder
+		regionalSetup   func(*fake.ClientBuilder) *fake.ClientBuilder
+		wantErr         bool
+		errContains     string
+	}{
+		{
+			name:            "Regional client used for kubeconfig lookup - missing secret on regional",
+			colony:          createTestColony(),
+			clusterName:     "cluster-a",
+			exposedEndpoint: "10.77.0.57:30443",
+			mgmtSetupFunc: func(builder *fake.ClientBuilder) *fake.ClientBuilder {
+				// Management cluster does NOT have the kubeconfig secret
+				return builder
+			},
+			regionalSetup: func(builder *fake.ClientBuilder) *fake.ClientBuilder {
+				// Regional cluster also does NOT have the secret
+				return builder
+			},
+			wantErr:     true,
+			errContains: "failed to get kubeconfig secret",
+		},
+		{
+			name:            "Regional client used for kubeconfig lookup - empty secret on regional",
+			colony:          createTestColony(),
+			clusterName:     "cluster-a",
+			exposedEndpoint: "10.77.0.57:30443",
+			mgmtSetupFunc: func(builder *fake.ClientBuilder) *fake.ClientBuilder {
+				return builder
+			},
+			regionalSetup: func(builder *fake.ClientBuilder) *fake.ClientBuilder {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-colony-cluster-a-kubeconfig",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{},
+				}
+				return builder.WithObjects(secret)
+			},
+			wantErr:     true,
+			errContains: "does not contain key 'value'",
+		},
+		{
+			name:            "Nil regional client falls back to management client",
+			colony:          createTestColony(),
+			clusterName:     "cluster-a",
+			exposedEndpoint: "10.77.0.57:30443",
+			mgmtSetupFunc: func(builder *fake.ClientBuilder) *fake.ClientBuilder {
+				// Management cluster has the secret (legacy path)
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-colony-cluster-a-kubeconfig",
+						Namespace: "default",
+					},
+					Data: map[string][]byte{
+						"value": []byte("invalid kubeconfig data"),
+					},
+				}
+				return builder.WithObjects(secret)
+			},
+			regionalSetup: nil, // nil regional client
+			wantErr:       true,
+			errContains:   "failed to create REST config", // Gets past secret lookup, fails at REST config
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgmtBuilder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.mgmtSetupFunc != nil {
+				mgmtBuilder = tt.mgmtSetupFunc(mgmtBuilder)
+			}
+			mgmtClient := mgmtBuilder.Build()
+
+			ctx := context.Background()
+
+			if tt.regionalSetup != nil {
+				regionalBuilder := fake.NewClientBuilder().WithScheme(scheme)
+				regionalBuilder = tt.regionalSetup(regionalBuilder)
+				regionalClient := regionalBuilder.Build()
+
+				err := EnsureAPIEndpointConfigMap(ctx, mgmtClient, tt.colony, tt.clusterName, tt.exposedEndpoint, scheme, regionalClient)
+
+				if tt.wantErr {
+					if err == nil {
+						t.Errorf("EnsureAPIEndpointConfigMap() expected error but got none")
+						return
+					}
+					if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+						t.Errorf("EnsureAPIEndpointConfigMap() error = %v, want error containing %q", err, tt.errContains)
+					}
+					return
+				}
+				if err != nil {
+					t.Errorf("EnsureAPIEndpointConfigMap() unexpected error = %v", err)
+				}
+			} else {
+				// Test with nil regional client (should fall back to management client)
+				err := EnsureAPIEndpointConfigMap(ctx, mgmtClient, tt.colony, tt.clusterName, tt.exposedEndpoint, scheme, nil)
+
+				if tt.wantErr {
+					if err == nil {
+						t.Errorf("EnsureAPIEndpointConfigMap() expected error but got none")
+						return
+					}
+					if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+						t.Errorf("EnsureAPIEndpointConfigMap() error = %v, want error containing %q", err, tt.errContains)
+					}
+					return
+				}
+				if err != nil {
+					t.Errorf("EnsureAPIEndpointConfigMap() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
 // Helper functions
 
 func createTestColony() *infrav1.Colony {

--- a/internal/controller/infra/colony_controller.go
+++ b/internal/controller/infra/colony_controller.go
@@ -181,24 +181,57 @@ func (r *ColonyReconciler) ensureAggregatedKubeconfigSecretExists(ctx context.Co
 	// iterate over all clusters in the colony
 	for _, clusterDeploymentRef := range colony.Status.ClusterDeploymentRefs {
 		kubeconfigSecretName := fmt.Sprintf("%s-kubeconfig", clusterDeploymentRef.Name)
+		clusterName := common.ExtractClusterNameFromDeploymentName(clusterDeploymentRef.Name, colony.Name)
 
+		// Check if this is a regional child cluster
 		var kubeconfigSecret corev1.Secret
-		if err := r.Get(ctx, client.ObjectKey{Namespace: clusterDeploymentRef.Namespace, Name: kubeconfigSecretName}, &kubeconfigSecret); err != nil {
-			if errors.IsNotFound(err) {
-				log.Info("Kubeconfig secret not found for cluster, will retry", "cluster", fmt.Sprintf("%s/%s", clusterDeploymentRef.Namespace, clusterDeploymentRef.Name))
-				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-			} else {
-				log.Error(err, "Failed to get Kubeconfig secret for cluster", "cluster", fmt.Sprintf("%s/%s", clusterDeploymentRef.Namespace, clusterDeploymentRef.Name))
+		regionalClient, isRegional, err := common.ResolveRegionalClient(ctx, r.Client, colony, clusterName, r.Scheme)
+		if err != nil {
+			log.Info("Failed to resolve regional client, falling back to management cluster",
+				"cluster", clusterDeploymentRef.Name, "error", err.Error())
+			// Fall back to management cluster lookup
+		}
+
+		if isRegional && regionalClient != nil {
+			// For regional children, the kubeconfig secret lives on the regional cluster.
+			// Fetch it from there and mirror it on the management cluster.
+			if err := regionalClient.Get(ctx, client.ObjectKey{Namespace: clusterDeploymentRef.Namespace, Name: kubeconfigSecretName}, &kubeconfigSecret); err != nil {
+				if errors.IsNotFound(err) {
+					log.Info("Kubeconfig secret not found on regional cluster, will retry",
+						"cluster", fmt.Sprintf("%s/%s", clusterDeploymentRef.Namespace, clusterDeploymentRef.Name))
+					return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+				}
+				log.Error(err, "Failed to get Kubeconfig secret from regional cluster",
+					"cluster", fmt.Sprintf("%s/%s", clusterDeploymentRef.Namespace, clusterDeploymentRef.Name))
 				return ctrl.Result{}, err
+			}
+
+			// Mirror the kubeconfig secret on the management cluster so downstream
+			// consumers (DDPJob controller, etc.) can find it
+			if err := r.mirrorKubeconfigSecret(ctx, colony, &kubeconfigSecret); err != nil {
+				log.Error(err, "Failed to mirror kubeconfig secret to management cluster",
+					"cluster", clusterDeploymentRef.Name)
+				return ctrl.Result{}, err
+			}
+		} else {
+			// Standard path: kubeconfig secret is on the management cluster
+			if err := r.Get(ctx, client.ObjectKey{Namespace: clusterDeploymentRef.Namespace, Name: kubeconfigSecretName}, &kubeconfigSecret); err != nil {
+				if errors.IsNotFound(err) {
+					log.Info("Kubeconfig secret not found for cluster, will retry", "cluster", fmt.Sprintf("%s/%s", clusterDeploymentRef.Namespace, clusterDeploymentRef.Name))
+					return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+				} else {
+					log.Error(err, "Failed to get Kubeconfig secret for cluster", "cluster", fmt.Sprintf("%s/%s", clusterDeploymentRef.Namespace, clusterDeploymentRef.Name))
+					return ctrl.Result{}, err
+				}
 			}
 		}
 
-		// Create an ObjectReference for the kubeconfig secret.
+		// Create an ObjectReference for the kubeconfig secret (always points to management cluster).
 		objRef := corev1.ObjectReference{
-			APIVersion: kubeconfigSecret.APIVersion,
-			Kind:       kubeconfigSecret.Kind,
-			Namespace:  kubeconfigSecret.Namespace,
-			Name:       kubeconfigSecret.Name,
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Namespace:  clusterDeploymentRef.Namespace,
+			Name:       kubeconfigSecretName,
 		}
 
 		// JSON-encode the ObjectReference.
@@ -257,6 +290,52 @@ func (r *ColonyReconciler) ensureAggregatedKubeconfigSecretExists(ctx context.Co
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// mirrorKubeconfigSecret creates or updates a copy of a kubeconfig secret on the management cluster.
+// This is used for regional children whose kubeconfig secrets live on the regional cluster.
+func (r *ColonyReconciler) mirrorKubeconfigSecret(ctx context.Context, colony *infrav1.Colony, sourceSecret *corev1.Secret) error {
+	log := log.FromContext(ctx)
+
+	mirrorSecret := &corev1.Secret{}
+	key := client.ObjectKey{Name: sourceSecret.Name, Namespace: colony.Namespace}
+
+	if err := r.Get(ctx, key, mirrorSecret); err != nil {
+		if errors.IsNotFound(err) {
+			// Create the mirror secret
+			mirrorSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourceSecret.Name,
+					Namespace: colony.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by":    "exalsius-operator",
+						"exalsius.ai/mirrored-kubeconfig": "true",
+						"exalsius.ai/colony":              colony.Name,
+					},
+				},
+				Data: sourceSecret.Data,
+			}
+			if err := r.Create(ctx, mirrorSecret); err != nil {
+				return fmt.Errorf("failed to create mirrored kubeconfig secret %q: %w", sourceSecret.Name, err)
+			}
+			log.Info("Created mirrored kubeconfig secret on management cluster",
+				"secret", sourceSecret.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to get mirrored kubeconfig secret %q: %w", sourceSecret.Name, err)
+	}
+
+	// Update existing mirror secret if data differs
+	if string(mirrorSecret.Data["value"]) != string(sourceSecret.Data["value"]) {
+		mirrorSecret.Data = sourceSecret.Data
+		if err := r.Update(ctx, mirrorSecret); err != nil {
+			return fmt.Errorf("failed to update mirrored kubeconfig secret %q: %w", sourceSecret.Name, err)
+		}
+		log.Info("Updated mirrored kubeconfig secret on management cluster",
+			"secret", sourceSecret.Name)
+	}
+
+	return nil
 }
 
 // handleColonyDeletion handles the deletion flow for a Colony resource.
@@ -473,8 +552,22 @@ func (r *ColonyReconciler) ensureAPIEndpointConfigMapForAllClusters(ctx context.
 			continue
 		}
 
+		// Check if this is a regional child cluster
+		regionalClient, isRegional, err := common.ResolveRegionalClient(ctx, r.Client, colony, clusterName, r.Scheme)
+		if err != nil {
+			log.Error(err, "Failed to resolve regional client, will retry", "cluster", clusterName)
+			continue
+		}
+
+		// Use regional client for service discovery if this is a regional child
+		discoveryClient := r.Client
+		if isRegional {
+			discoveryClient = regionalClient
+			log.Info("Using regional cluster client for service discovery", "cluster", clusterName)
+		}
+
 		// Discover the control plane service for this cluster
-		service, err := common.DiscoverControlPlaneService(ctx, r.Client, colony.Namespace, colony.Name, clusterName)
+		service, err := common.DiscoverControlPlaneService(ctx, discoveryClient, colony.Namespace, colony.Name, clusterName)
 		if err != nil {
 			// Service not found is expected during provisioning - don't log as error
 			if strings.Contains(err.Error(), "not found yet") || strings.Contains(err.Error(), "still provisioning") {
@@ -499,7 +592,8 @@ func (r *ColonyReconciler) ensureAPIEndpointConfigMapForAllClusters(ctx context.
 			"serviceType", service.Spec.Type)
 
 		// Create/update the ConfigMap in the child cluster
-		if err := cilium.EnsureAPIEndpointConfigMap(ctx, r.Client, colony, clusterName, endpoint, r.Scheme); err != nil {
+		// For regional children, pass the regional client so kubeconfig can be fetched from the regional cluster
+		if err := cilium.EnsureAPIEndpointConfigMap(ctx, r.Client, colony, clusterName, endpoint, r.Scheme, regionalClient); err != nil {
 			// Distinguish between "not ready yet" (expected) and actual errors
 			if errors.IsNotFound(err) || isConnectionError(err) {
 				log.Info("Child cluster not ready yet, will retry ConfigMap creation on next reconcile",

--- a/internal/controller/infra/common/regional.go
+++ b/internal/controller/infra/common/regional.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	k0rdentv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
+	infrav1 "github.com/exalsius/exalsius-operator/api/infra/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// LabelKOFRegionalClusterName is the label on a ColonyCluster that indicates
+	// it is a child of a regional cluster. The value is the regional cluster's name.
+	LabelKOFRegionalClusterName = "k0rdent.mirantis.com/kof-regional-cluster-name"
+
+	// LabelKOFClusterName is the label on a ClusterDeployment that identifies
+	// the cluster by its logical name (used to find the regional ClusterDeployment).
+	LabelKOFClusterName = "k0rdent.mirantis.com/kof-cluster-name"
+)
+
+// IsRegionalChild checks if a ColonyCluster is a child of a regional cluster.
+// Returns (true, regionalName) if the cluster has the regional cluster label,
+// (false, "") otherwise. This is the sole detection mechanism — no label means
+// legacy behavior, full backward compatibility.
+func IsRegionalChild(colonyCluster *infrav1.ColonyCluster) (bool, string) {
+	if colonyCluster.ClusterLabels == nil {
+		return false, ""
+	}
+	regionalName, ok := colonyCluster.ClusterLabels[LabelKOFRegionalClusterName]
+	if !ok || regionalName == "" {
+		return false, ""
+	}
+	return true, regionalName
+}
+
+// FindRegionalClusterDeployment finds the ClusterDeployment for a regional cluster
+// by matching the label k0rdent.mirantis.com/kof-cluster-name=<regionalClusterName>.
+func FindRegionalClusterDeployment(ctx context.Context, c client.Client, namespace, regionalClusterName string) (*k0rdentv1beta1.ClusterDeployment, error) {
+	log := log.FromContext(ctx)
+
+	cdList := &k0rdentv1beta1.ClusterDeploymentList{}
+	if err := c.List(ctx, cdList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{LabelKOFClusterName: regionalClusterName},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list ClusterDeployments for regional cluster %q: %w", regionalClusterName, err)
+	}
+
+	if len(cdList.Items) == 0 {
+		return nil, fmt.Errorf("no ClusterDeployment found with label %s=%s in namespace %s",
+			LabelKOFClusterName, regionalClusterName, namespace)
+	}
+
+	if len(cdList.Items) > 1 {
+		log.Info("Multiple ClusterDeployments found for regional cluster, using first",
+			"regionalCluster", regionalClusterName,
+			"count", len(cdList.Items))
+	}
+
+	return &cdList.Items[0], nil
+}
+
+// GetRegionalClusterClient builds a controller-runtime client for a regional cluster.
+// It fetches the regional cluster's kubeconfig secret from the management cluster
+// and creates a client that can talk to the regional cluster's API server.
+func GetRegionalClusterClient(ctx context.Context, managementClient client.Client, namespace, regionalCDName string, scheme *runtime.Scheme) (client.Client, error) {
+	log := log.FromContext(ctx)
+
+	kubeconfigSecretName := fmt.Sprintf("%s-kubeconfig", regionalCDName)
+
+	var kubeconfigSecret corev1.Secret
+	if err := managementClient.Get(ctx, client.ObjectKey{
+		Name:      kubeconfigSecretName,
+		Namespace: namespace,
+	}, &kubeconfigSecret); err != nil {
+		return nil, fmt.Errorf("failed to get regional cluster kubeconfig secret %q: %w", kubeconfigSecretName, err)
+	}
+
+	kubeconfigBytes, ok := kubeconfigSecret.Data["value"]
+	if !ok {
+		return nil, fmt.Errorf("regional cluster kubeconfig secret %q does not contain key 'value'", kubeconfigSecretName)
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST config for regional cluster %q: %w", regionalCDName, err)
+	}
+
+	regionalClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client for regional cluster %q: %w", regionalCDName, err)
+	}
+
+	log.V(1).Info("Created client for regional cluster",
+		"regionalClusterDeployment", regionalCDName,
+		"kubeconfigSecret", kubeconfigSecretName)
+
+	return regionalClient, nil
+}
+
+// GetColonyClusterByName looks up a ColonyCluster from the Colony spec by clusterName.
+func GetColonyClusterByName(colony *infrav1.Colony, clusterName string) *infrav1.ColonyCluster {
+	for i := range colony.Spec.ColonyClusters {
+		if colony.Spec.ColonyClusters[i].ClusterName == clusterName {
+			return &colony.Spec.ColonyClusters[i]
+		}
+	}
+	return nil
+}
+
+// ResolveRegionalClient checks if a cluster is a regional child and, if so,
+// builds a client for the regional cluster. Returns (regionalClient, isRegional, error).
+// If the cluster is not a regional child, returns (nil, false, nil).
+func ResolveRegionalClient(
+	ctx context.Context,
+	managementClient client.Client,
+	colony *infrav1.Colony,
+	clusterName string,
+	scheme *runtime.Scheme,
+) (client.Client, bool, error) {
+	log := log.FromContext(ctx)
+
+	colonyCluster := GetColonyClusterByName(colony, clusterName)
+	if colonyCluster == nil {
+		return nil, false, nil
+	}
+
+	isRegional, regionalName := IsRegionalChild(colonyCluster)
+	if !isRegional {
+		return nil, false, nil
+	}
+
+	log.Info("Cluster is a regional child, resolving regional cluster client",
+		"cluster", clusterName,
+		"regionalCluster", regionalName)
+
+	// Find the regional ClusterDeployment
+	regionalCD, err := FindRegionalClusterDeployment(ctx, managementClient, colony.Namespace, regionalName)
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to find regional ClusterDeployment for %q: %w", regionalName, err)
+	}
+
+	// Build client for the regional cluster
+	regionalClient, err := GetRegionalClusterClient(ctx, managementClient, colony.Namespace, regionalCD.Name, scheme)
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to get regional cluster client for %q: %w", regionalName, err)
+	}
+
+	return regionalClient, true, nil
+}

--- a/internal/controller/infra/common/regional_test.go
+++ b/internal/controller/infra/common/regional_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	k0rdentv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
+	infrav1 "github.com/exalsius/exalsius-operator/api/infra/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestIsRegionalChild(t *testing.T) {
+	tests := []struct {
+		name             string
+		colonyCluster    *infrav1.ColonyCluster
+		wantIsRegional   bool
+		wantRegionalName string
+	}{
+		{
+			name: "Regional child with label",
+			colonyCluster: &infrav1.ColonyCluster{
+				ClusterName: "testchild",
+				ClusterLabels: map[string]string{
+					LabelKOFRegionalClusterName: "regional-cluster",
+				},
+			},
+			wantIsRegional:   true,
+			wantRegionalName: "regional-cluster",
+		},
+		{
+			name: "Non-regional cluster (no label)",
+			colonyCluster: &infrav1.ColonyCluster{
+				ClusterName: "testchild",
+				ClusterLabels: map[string]string{
+					"some-other-label": "value",
+				},
+			},
+			wantIsRegional:   false,
+			wantRegionalName: "",
+		},
+		{
+			name: "Nil labels",
+			colonyCluster: &infrav1.ColonyCluster{
+				ClusterName: "testchild",
+			},
+			wantIsRegional:   false,
+			wantRegionalName: "",
+		},
+		{
+			name: "Empty regional label value",
+			colonyCluster: &infrav1.ColonyCluster{
+				ClusterName: "testchild",
+				ClusterLabels: map[string]string{
+					LabelKOFRegionalClusterName: "",
+				},
+			},
+			wantIsRegional:   false,
+			wantRegionalName: "",
+		},
+		{
+			name: "Regional child with additional labels",
+			colonyCluster: &infrav1.ColonyCluster{
+				ClusterName: "testchild",
+				ClusterLabels: map[string]string{
+					LabelKOFRegionalClusterName: "my-regional",
+					"environment":               "staging",
+				},
+			},
+			wantIsRegional:   true,
+			wantRegionalName: "my-regional",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isRegional, regionalName := IsRegionalChild(tt.colonyCluster)
+			if isRegional != tt.wantIsRegional {
+				t.Errorf("IsRegionalChild() isRegional = %v, want %v", isRegional, tt.wantIsRegional)
+			}
+			if regionalName != tt.wantRegionalName {
+				t.Errorf("IsRegionalChild() regionalName = %q, want %q", regionalName, tt.wantRegionalName)
+			}
+		})
+	}
+}
+
+func TestFindRegionalClusterDeployment(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = k0rdentv1beta1.AddToScheme(scheme)
+
+	tests := []struct {
+		name                string
+		namespace           string
+		regionalClusterName string
+		clusterDeployments  []k0rdentv1beta1.ClusterDeployment
+		wantErr             bool
+		errContains         string
+		wantCDName          string
+	}{
+		{
+			name:                "Found regional ClusterDeployment by label",
+			namespace:           "default",
+			regionalClusterName: "regional-cluster",
+			clusterDeployments: []k0rdentv1beta1.ClusterDeployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default-regional-cluster",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelKOFClusterName: "regional-cluster",
+						},
+					},
+				},
+			},
+			wantErr:    false,
+			wantCDName: "default-regional-cluster",
+		},
+		{
+			name:                "No matching ClusterDeployment",
+			namespace:           "default",
+			regionalClusterName: "nonexistent-regional",
+			clusterDeployments:  []k0rdentv1beta1.ClusterDeployment{},
+			wantErr:             true,
+			errContains:         "no ClusterDeployment found",
+		},
+		{
+			name:                "ClusterDeployment in different namespace (should not match)",
+			namespace:           "default",
+			regionalClusterName: "regional-cluster",
+			clusterDeployments: []k0rdentv1beta1.ClusterDeployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-regional-cluster",
+						Namespace: "other-namespace",
+						Labels: map[string]string{
+							LabelKOFClusterName: "regional-cluster",
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "no ClusterDeployment found",
+		},
+		{
+			name:                "Multiple matching ClusterDeployments (returns first)",
+			namespace:           "default",
+			regionalClusterName: "regional-cluster",
+			clusterDeployments: []k0rdentv1beta1.ClusterDeployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "first-regional",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelKOFClusterName: "regional-cluster",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "second-regional",
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelKOFClusterName: "regional-cluster",
+						},
+					},
+				},
+			},
+			wantErr: false,
+			// Returns first match
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			for i := range tt.clusterDeployments {
+				builder = builder.WithObjects(&tt.clusterDeployments[i])
+			}
+			c := builder.Build()
+
+			ctx := context.Background()
+			cd, err := FindRegionalClusterDeployment(ctx, c, tt.namespace, tt.regionalClusterName)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("FindRegionalClusterDeployment() expected error but got none")
+					return
+				}
+				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Errorf("FindRegionalClusterDeployment() error = %v, want error containing %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("FindRegionalClusterDeployment() unexpected error = %v", err)
+				return
+			}
+
+			if tt.wantCDName != "" && cd.Name != tt.wantCDName {
+				t.Errorf("FindRegionalClusterDeployment() CD name = %q, want %q", cd.Name, tt.wantCDName)
+			}
+		})
+	}
+}
+
+func TestGetColonyClusterByName(t *testing.T) {
+	colony := &infrav1.Colony{
+		Spec: infrav1.ColonySpec{
+			ColonyClusters: []infrav1.ColonyCluster{
+				{ClusterName: "cluster-a"},
+				{ClusterName: "cluster-b", ClusterLabels: map[string]string{"env": "prod"}},
+				{ClusterName: "cluster-c"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		clusterName string
+		wantFound   bool
+		wantName    string
+	}{
+		{
+			name:        "Found first cluster",
+			clusterName: "cluster-a",
+			wantFound:   true,
+			wantName:    "cluster-a",
+		},
+		{
+			name:        "Found middle cluster",
+			clusterName: "cluster-b",
+			wantFound:   true,
+			wantName:    "cluster-b",
+		},
+		{
+			name:        "Found last cluster",
+			clusterName: "cluster-c",
+			wantFound:   true,
+			wantName:    "cluster-c",
+		},
+		{
+			name:        "Cluster not found",
+			clusterName: "nonexistent",
+			wantFound:   false,
+		},
+		{
+			name:        "Empty cluster name",
+			clusterName: "",
+			wantFound:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetColonyClusterByName(colony, tt.clusterName)
+			if tt.wantFound {
+				if result == nil {
+					t.Errorf("GetColonyClusterByName() returned nil, want %q", tt.wantName)
+					return
+				}
+				if result.ClusterName != tt.wantName {
+					t.Errorf("GetColonyClusterByName() name = %q, want %q", result.ClusterName, tt.wantName)
+				}
+			} else {
+				if result != nil {
+					t.Errorf("GetColonyClusterByName() returned %q, want nil", result.ClusterName)
+				}
+			}
+		})
+	}
+}
+
+func TestGetColonyClusterByName_EmptyColony(t *testing.T) {
+	colony := &infrav1.Colony{
+		Spec: infrav1.ColonySpec{
+			ColonyClusters: []infrav1.ColonyCluster{},
+		},
+	}
+
+	result := GetColonyClusterByName(colony, "any-name")
+	if result != nil {
+		t.Errorf("GetColonyClusterByName() on empty colony returned %v, want nil", result)
+	}
+}

--- a/internal/controller/infra/netbird/netbird.go
+++ b/internal/controller/infra/netbird/netbird.go
@@ -282,8 +282,22 @@ func reconcileControlPlaneExposure(
 ) error {
 	log := log.FromContext(ctx)
 
+	// Check if this is a regional child cluster
+	regionalClient, isRegional, err := common.ResolveRegionalClient(ctx, c, colony, clusterName, scheme)
+	if err != nil {
+		return fmt.Errorf("failed to resolve regional client for cluster %q: %w", clusterName, err)
+	}
+
+	// Determine which client to use for service discovery and kubeconfig lookup
+	discoveryClient := c
+	if isRegional {
+		discoveryClient = regionalClient
+		log.Info("Using regional cluster client for service discovery",
+			"cluster", clusterName)
+	}
+
 	// Discover control plane service
-	service, err := common.DiscoverControlPlaneService(ctx, c, colony.Namespace, colony.Name, clusterName)
+	service, err := common.DiscoverControlPlaneService(ctx, discoveryClient, colony.Namespace, colony.Name, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to discover control plane service: %w", err)
 	}
@@ -381,7 +395,8 @@ func reconcileControlPlaneExposure(
 	// Create/update the Cilium API endpoint ConfigMap in the child cluster
 	// This must happen as soon as the endpoint is known, so Cilium can start properly
 	// Note: Use ciliumEndpoint (internal DNS for NodePort, external for LoadBalancer)
-	if err := cilium.EnsureAPIEndpointConfigMap(ctx, c, colony, clusterName, ciliumEndpoint, scheme); err != nil {
+	// For regional children, pass the regional client so kubeconfig can be fetched from the regional cluster
+	if err := cilium.EnsureAPIEndpointConfigMap(ctx, c, colony, clusterName, ciliumEndpoint, scheme, regionalClient); err != nil {
 		// Distinguish between "not ready yet" (expected) and actual errors
 		if errors.IsNotFound(err) || isConnectionError(err) {
 			log.Info("Child cluster not ready yet, will retry Cilium ConfigMap creation on next reconcile",


### PR DESCRIPTION
## Description

When a child cluster is provisioned under a regional cluster, k0smotron creates control plane services and kubeconfig secrets on the regional cluster, not the management cluster. This adds detection via the k0rdent.mirantis.com/kof-regional-cluster-name label and builds a regional cluster client to perform service discovery, Cilium ConfigMap creation, and kubeconfig mirroring from the correct cluster.

## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->