### PR TITLE
fix: delete etcd PVCs on regional cluster for regional child clusters

### DIFF
--- a/internal/controller/infra/clusterdeployment/clusterdeployment.go
+++ b/internal/controller/infra/clusterdeployment/clusterdeployment.go
@@ -9,6 +9,7 @@ import (
 
 	k0rdentv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
 	infrav1 "github.com/exalsius/exalsius-operator/api/infra/v1"
+	"github.com/exalsius/exalsius-operator/internal/controller/infra/common"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -279,7 +280,7 @@ func updateColonyStatusWithRetry(ctx context.Context, c client.Client, colony *i
 // referenced in the Colony spec but still exist in the status.
 // Returns (hasPendingDeletions, error) - hasPendingDeletions is true if there are still
 // ClusterDeployments being deleted that require a requeue.
-func CleanupOrphanedClusterDeployments(ctx context.Context, c client.Client, colony *infrav1.Colony) (bool, error) {
+func CleanupOrphanedClusterDeployments(ctx context.Context, c client.Client, colony *infrav1.Colony, scheme *runtime.Scheme) (bool, error) {
 	log := log.FromContext(ctx)
 
 	// Create a set of expected cluster names from the spec
@@ -310,7 +311,7 @@ func CleanupOrphanedClusterDeployments(ctx context.Context, c client.Client, col
 						Namespace: ref.Namespace,
 					},
 				}
-				if err := DeletePVCForClusterDeployment(ctx, c, pvcClusterDeployment); err != nil {
+				if err := DeletePVCForClusterDeployment(ctx, c, pvcClusterDeployment, colony, scheme); err != nil {
 					log.Error(err, "Failed to delete PVC for ClusterDeployment", "ClusterDeployment.Name", ref.Name)
 					// Don't return error here as the main deletion was successful
 				}
@@ -369,9 +370,51 @@ func CleanupOrphanedClusterDeployments(ctx context.Context, c client.Client, col
 	return len(pendingDeletions) > 0, nil
 }
 
-// DeletePVCForClusterDeployment deletes the PVC associated with a ClusterDeployment
-func DeletePVCForClusterDeployment(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment) error {
+// DeletePVCForClusterDeployment deletes the PVC associated with a ClusterDeployment.
+// For regional child clusters, it resolves a client for the regional cluster and deletes the PVC there.
+// For standard clusters, it deletes the PVC on the management cluster using c.
+// If the regional client cannot be resolved (e.g. kubeconfig secret already deleted),
+// the error is logged and nil is returned — the PVC is likely already gone with the regional cluster.
+func DeletePVCForClusterDeployment(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment, colony *infrav1.Colony, scheme *runtime.Scheme) error {
 	log := log.FromContext(ctx)
+
+	// Determine which client to use for PVC deletion
+	pvcClient := c
+
+	// Match ClusterDeployment to a ColonyCluster to check if it's a regional child
+	for i := range colony.Spec.ColonyClusters {
+		colonyCluster := &colony.Spec.ColonyClusters[i]
+		expectedName := colony.Name + "-" + colonyCluster.ClusterName
+		if expectedName != clusterDeployment.Name {
+			continue
+		}
+
+		isRegional, regionalName := common.IsRegionalChild(colonyCluster)
+		if !isRegional {
+			break
+		}
+
+		log.Info("ClusterDeployment is a regional child, resolving regional client for PVC cleanup",
+			"ClusterDeployment.Name", clusterDeployment.Name,
+			"regionalCluster", regionalName)
+
+		regionalCD, err := common.FindRegionalClusterDeployment(ctx, c, colony.Namespace, regionalName)
+		if err != nil {
+			log.Info("Could not find regional ClusterDeployment, PVC likely already cleaned up",
+				"regionalCluster", regionalName, "error", err)
+			return nil
+		}
+
+		regionalClient, err := common.GetRegionalClusterClient(ctx, c, colony.Namespace, regionalCD.Name, scheme)
+		if err != nil {
+			log.Info("Could not create regional cluster client, PVC likely already cleaned up",
+				"regionalCluster", regionalName, "error", err)
+			return nil
+		}
+
+		pvcClient = regionalClient
+		break
+	}
 
 	// Construct PVC name following the pattern: etcd-data-kmc-<cluster-deployment-name>-etcd-0
 	pvcName := fmt.Sprintf("etcd-data-kmc-%s-etcd-0", clusterDeployment.Name)
@@ -383,7 +426,7 @@ func DeletePVCForClusterDeployment(ctx context.Context, c client.Client, cluster
 		},
 	}
 
-	if err := c.Delete(ctx, pvc); err != nil {
+	if err := pvcClient.Delete(ctx, pvc); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("PVC not found, already deleted or never existed", "PVC.Name", pvcName, "PVC.Namespace", clusterDeployment.Namespace)
 			return nil
@@ -397,7 +440,7 @@ func DeletePVCForClusterDeployment(ctx context.Context, c client.Client, cluster
 }
 
 // WaitForClusterDeletion polls until the given ClusterDeployment is no longer found.
-func WaitForClusterDeletion(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment, timeout, interval time.Duration) error {
+func WaitForClusterDeletion(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment, colony *infrav1.Colony, scheme *runtime.Scheme, timeout, interval time.Duration) error {
 	log := log.FromContext(ctx)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -414,7 +457,7 @@ func WaitForClusterDeletion(ctx context.Context, c client.Client, clusterDeploym
 				log.Info("ClusterDeployment deleted", "ClusterDeployment.Namespace", clusterDeployment.Namespace, "ClusterDeployment.Name", clusterDeployment.Name)
 
 				// Delete the associated PVC after ClusterDeployment is confirmed deleted
-				if err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment); err != nil {
+				if err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme); err != nil {
 					log.Error(err, "Failed to delete PVC for ClusterDeployment", "ClusterDeployment.Name", clusterDeployment.Name)
 					// Don't return error here as the main deletion was successful
 				}

--- a/internal/controller/infra/clusterdeployment/clusterdeployment_test.go
+++ b/internal/controller/infra/clusterdeployment/clusterdeployment_test.go
@@ -13,6 +13,7 @@ import (
 
 	k0rdentv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
 	infrav1 "github.com/exalsius/exalsius-operator/api/infra/v1"
+	"github.com/exalsius/exalsius-operator/internal/controller/infra/common"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -544,6 +545,7 @@ var _ = Describe("EnsureClusterDeployment", func() {
 var _ = Describe("WaitForClusterDeletion", func() {
 	var (
 		scheme            *runtime.Scheme
+		colony            *infrav1.Colony
 		clusterDeployment *k0rdentv1beta1.ClusterDeployment
 		ctx               context.Context
 	)
@@ -551,7 +553,20 @@ var _ = Describe("WaitForClusterDeletion", func() {
 	BeforeEach(func() {
 		scheme = runtime.NewScheme()
 		_ = k0rdentv1beta1.AddToScheme(scheme)
+		_ = infrav1.AddToScheme(scheme)
 		_ = corev1.AddToScheme(scheme)
+
+		colony = &infrav1.Colony{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: infrav1.ColonySpec{
+				ColonyClusters: []infrav1.ColonyCluster{
+					{ClusterName: "cluster"},
+				},
+			},
+		}
 
 		clusterDeployment = &k0rdentv1beta1.ClusterDeployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -586,7 +601,7 @@ var _ = Describe("WaitForClusterDeletion", func() {
 			Build()
 
 		// Since ClusterDeployment doesn't exist, the function should immediately detect it's "deleted" and delete the PVC
-		err := WaitForClusterDeletion(ctx, c, clusterDeployment, 1*time.Second, 100*time.Millisecond)
+		err := WaitForClusterDeletion(ctx, c, clusterDeployment, colony, scheme, 1*time.Second, 100*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify PVC was deleted
@@ -603,7 +618,7 @@ var _ = Describe("WaitForClusterDeletion", func() {
 
 		// Since ClusterDeployment doesn't exist, the function should immediately detect it's "deleted" and try to delete PVC
 		// But since PVC doesn't exist either, it should handle the NotFound error gracefully
-		err := WaitForClusterDeletion(ctx, c, clusterDeployment, 1*time.Second, 100*time.Millisecond)
+		err := WaitForClusterDeletion(ctx, c, clusterDeployment, colony, scheme, 1*time.Second, 100*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred())
 		// Should not have any additional errors related to PVC deletion
 	})
@@ -641,7 +656,7 @@ var _ = Describe("WaitForClusterDeletion", func() {
 		Expect(c.Create(ctx, pvc)).To(Succeed())
 
 		// Wait for deletion with a short timeout
-		err := WaitForClusterDeletion(ctx, c, clusterDeployment, 2*time.Second, 50*time.Millisecond)
+		err := WaitForClusterDeletion(ctx, c, clusterDeployment, colony, scheme, 2*time.Second, 50*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify PVC was deleted
@@ -693,7 +708,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeFalse())
 			// Status should be unchanged
@@ -727,7 +742,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeFalse())
 			// Orphaned ref should be removed from status
@@ -775,7 +790,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony, pvc).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeFalse())
 
@@ -821,7 +836,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony, orphanedCD).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeTrue()) // Should indicate pending deletion
 
@@ -873,7 +888,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony, orphanedCD).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeTrue()) // Deletion is pending
 
@@ -933,7 +948,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony, cd3, cd4).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeTrue()) // cluster-4 is still pending
 
@@ -979,7 +994,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeFalse())
 
@@ -1012,7 +1027,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeFalse())
 		})
@@ -1041,7 +1056,7 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeFalse())
 		})
@@ -1071,12 +1086,240 @@ var _ = Describe("CleanupOrphanedClusterDeployments", func() {
 				WithObjects(colony).
 				Build()
 
-			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony)
+			hasPending, err := CleanupOrphanedClusterDeployments(ctx, c, colony, scheme)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hasPending).To(BeFalse()) // Both were already deleted (not found)
 
 			// Both should be removed from status
 			Expect(colony.Status.ClusterDeploymentRefs).To(BeEmpty())
 		})
+	})
+})
+
+var _ = Describe("DeletePVCForClusterDeployment", func() {
+	var (
+		scheme *runtime.Scheme
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		_ = k0rdentv1beta1.AddToScheme(scheme)
+		_ = infrav1.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
+		ctx = context.TODO()
+	})
+
+	It("should delete PVC on management cluster for standard (non-regional) cluster", func() {
+		colony := &infrav1.Colony{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony",
+				Namespace: "default",
+			},
+			Spec: infrav1.ColonySpec{
+				ColonyClusters: []infrav1.ColonyCluster{
+					{ClusterName: "cluster-1"},
+				},
+			},
+		}
+
+		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-cluster-1",
+				Namespace: "default",
+			},
+		}
+
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd-data-kmc-test-colony-cluster-1-etcd-0",
+				Namespace: "default",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pvc).
+			Build()
+
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify PVC was deleted from management cluster
+		deletedPVC := &corev1.PersistentVolumeClaim{}
+		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-cluster-1-etcd-0", Namespace: "default"}, deletedPVC)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("should return nil when regional child's kubeconfig secret is not found", func() {
+		// Regional cluster CD must exist so FindRegionalClusterDeployment can find it
+		regionalCD := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-regional-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					common.LabelKOFClusterName: "regional-1",
+				},
+			},
+		}
+
+		colony := &infrav1.Colony{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony",
+				Namespace: "default",
+			},
+			Spec: infrav1.ColonySpec{
+				ColonyClusters: []infrav1.ColonyCluster{
+					{
+						ClusterName: "child-1",
+						ClusterLabels: map[string]string{
+							common.LabelKOFRegionalClusterName: "regional-1",
+						},
+					},
+				},
+			},
+		}
+
+		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-child-1",
+				Namespace: "default",
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(regionalCD).
+			Build()
+
+		// No kubeconfig secret exists for regional cluster — should return nil gracefully
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not delete PVC on management cluster for regional child", func() {
+		// Regional cluster CD exists but no kubeconfig secret
+		regionalCD := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-regional-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					common.LabelKOFClusterName: "regional-1",
+				},
+			},
+		}
+
+		colony := &infrav1.Colony{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony",
+				Namespace: "default",
+			},
+			Spec: infrav1.ColonySpec{
+				ColonyClusters: []infrav1.ColonyCluster{
+					{
+						ClusterName: "child-1",
+						ClusterLabels: map[string]string{
+							common.LabelKOFRegionalClusterName: "regional-1",
+						},
+					},
+				},
+			},
+		}
+
+		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-child-1",
+				Namespace: "default",
+			},
+		}
+
+		// PVC exists on management cluster — should NOT be deleted since this is a regional child
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd-data-kmc-test-colony-child-1-etcd-0",
+				Namespace: "default",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(regionalCD, pvc).
+			Build()
+
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		// PVC on management cluster should still exist — it was not deleted
+		existingPVC := &corev1.PersistentVolumeClaim{}
+		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-child-1-etcd-0", Namespace: "default"}, existingPVC)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fall back to management client when no matching ColonyCluster is found", func() {
+		colony := &infrav1.Colony{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony",
+				Namespace: "default",
+			},
+			Spec: infrav1.ColonySpec{
+				ColonyClusters: []infrav1.ColonyCluster{
+					{ClusterName: "cluster-1"},
+				},
+			},
+		}
+
+		// CD name doesn't match any colony-cluster combination
+		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-unknown-cluster",
+				Namespace: "default",
+			},
+		}
+
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd-data-kmc-test-colony-unknown-cluster-etcd-0",
+				Namespace: "default",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pvc).
+			Build()
+
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		// PVC should be deleted from management cluster (fallback behavior)
+		deletedPVC := &corev1.PersistentVolumeClaim{}
+		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-unknown-cluster-etcd-0", Namespace: "default"}, deletedPVC)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 })

--- a/internal/controller/infra/colony_controller.go
+++ b/internal/controller/infra/colony_controller.go
@@ -101,7 +101,7 @@ func (r *ColonyReconciler) reconcileColony(ctx context.Context, colony *infrav1.
 	log := log.FromContext(ctx)
 
 	// Clean up ClusterDeployments that are no longer in the spec (non-blocking)
-	hasPendingDeletions, err := clusterdeployment.CleanupOrphanedClusterDeployments(ctx, r.Client, colony)
+	hasPendingDeletions, err := clusterdeployment.CleanupOrphanedClusterDeployments(ctx, r.Client, colony, r.Scheme)
 	if err != nil {
 		log.Error(err, "Failed to cleanup orphaned cluster deployments")
 		return ctrl.Result{}, err
@@ -431,7 +431,7 @@ func (r *ColonyReconciler) cleanupAssociatedResources(ctx context.Context, colon
 				Namespace: colony.Namespace,
 			},
 		}
-		if err := clusterdeployment.DeletePVCForClusterDeployment(ctx, r.Client, pvcClusterDeployment); err != nil {
+		if err := clusterdeployment.DeletePVCForClusterDeployment(ctx, r.Client, pvcClusterDeployment, colony, r.Scheme); err != nil {
 			log.Error(err, "Failed to delete PVC for ClusterDeployment", "ClusterDeployment.Name", clusterDeploymentName)
 			// Don't return error here as the main deletion was successful
 		}


### PR DESCRIPTION
## Description

  - `DeletePVCForClusterDeployment` previously always deleted the etcd PVC on the management cluster. For regional child clusters, the PVC lives on the regional cluster, so it was never actually cleaned up.                       
  - The function now resolves the correct client by matching the ClusterDeployment to its ColonyCluster, checking `IsRegionalChild()`, and building a regional cluster client when needed. If the regional cluster is unreachable    
  (e.g. already torn down), the error is swallowed, the PVC is gone with the cluster.                                                                                                                                               
  - Updated signatures of `CleanupOrphanedClusterDeployments` and `WaitForClusterDeletion` to pass through `colony` and `scheme`.
      
## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->