### PR TITLE
fix: discover regional clusters by label for PVC cleanup 

### DIFF
--- a/internal/controller/infra/clusterdeployment/clusterdeployment.go
+++ b/internal/controller/infra/clusterdeployment/clusterdeployment.go
@@ -311,7 +311,7 @@ func CleanupOrphanedClusterDeployments(ctx context.Context, c client.Client, col
 						Namespace: ref.Namespace,
 					},
 				}
-				if err := DeletePVCForClusterDeployment(ctx, c, pvcClusterDeployment, colony, scheme); err != nil {
+				if err := DeletePVCForClusterDeployment(ctx, c, pvcClusterDeployment, scheme); err != nil {
 					log.Error(err, "Failed to delete PVC for ClusterDeployment", "ClusterDeployment.Name", ref.Name)
 					// Don't return error here as the main deletion was successful
 				}
@@ -371,76 +371,74 @@ func CleanupOrphanedClusterDeployments(ctx context.Context, c client.Client, col
 }
 
 // DeletePVCForClusterDeployment deletes the PVC associated with a ClusterDeployment.
-// For regional child clusters, it resolves a client for the regional cluster and deletes the PVC there.
-// For standard clusters, it deletes the PVC on the management cluster using c.
+// It first tries the management cluster. If the PVC is not found there, it checks
+// whether a regional cluster exists in the namespace (by label kof-cluster-role=regional)
+// and tries deleting the PVC on the regional cluster instead.
 // If the regional client cannot be resolved (e.g. kubeconfig secret already deleted),
 // the error is logged and nil is returned — the PVC is likely already gone with the regional cluster.
-func DeletePVCForClusterDeployment(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment, colony *infrav1.Colony, scheme *runtime.Scheme) error {
+func DeletePVCForClusterDeployment(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment, scheme *runtime.Scheme) error {
 	log := log.FromContext(ctx)
 
-	// Determine which client to use for PVC deletion
-	pvcClient := c
-
-	// Match ClusterDeployment to a ColonyCluster to check if it's a regional child
-	for i := range colony.Spec.ColonyClusters {
-		colonyCluster := &colony.Spec.ColonyClusters[i]
-		expectedName := colony.Name + "-" + colonyCluster.ClusterName
-		if expectedName != clusterDeployment.Name {
-			continue
-		}
-
-		isRegional, regionalName := common.IsRegionalChild(colonyCluster)
-		if !isRegional {
-			break
-		}
-
-		log.Info("ClusterDeployment is a regional child, resolving regional client for PVC cleanup",
-			"ClusterDeployment.Name", clusterDeployment.Name,
-			"regionalCluster", regionalName)
-
-		regionalCD, err := common.FindRegionalClusterDeployment(ctx, c, colony.Namespace, regionalName)
-		if err != nil {
-			log.Info("Could not find regional ClusterDeployment, PVC likely already cleaned up",
-				"regionalCluster", regionalName, "error", err)
-			return nil
-		}
-
-		regionalClient, err := common.GetRegionalClusterClient(ctx, c, colony.Namespace, regionalCD.Name, scheme)
-		if err != nil {
-			log.Info("Could not create regional cluster client, PVC likely already cleaned up",
-				"regionalCluster", regionalName, "error", err)
-			return nil
-		}
-
-		pvcClient = regionalClient
-		break
-	}
-
-	// Construct PVC name following the pattern: etcd-data-kmc-<cluster-deployment-name>-etcd-0
 	pvcName := fmt.Sprintf("etcd-data-kmc-%s-etcd-0", clusterDeployment.Name)
+	namespace := clusterDeployment.Namespace
 
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
-			Namespace: clusterDeployment.Namespace,
+			Namespace: namespace,
 		},
 	}
 
-	if err := pvcClient.Delete(ctx, pvc); err != nil {
-		if errors.IsNotFound(err) {
-			log.Info("PVC not found, already deleted or never existed", "PVC.Name", pvcName, "PVC.Namespace", clusterDeployment.Namespace)
-			return nil
-		}
-		log.Error(err, "Failed to delete PVC", "PVC.Name", pvcName, "PVC.Namespace", clusterDeployment.Namespace)
+	// Try management cluster first
+	if err := c.Delete(ctx, pvc); err == nil {
+		log.Info("PVC deleted successfully from management cluster", "PVC.Name", pvcName, "PVC.Namespace", namespace)
+		return nil
+	} else if !errors.IsNotFound(err) {
+		log.Error(err, "Failed to delete PVC from management cluster", "PVC.Name", pvcName, "PVC.Namespace", namespace)
 		return err
 	}
 
-	log.Info("PVC deleted successfully", "PVC.Name", pvcName, "PVC.Namespace", clusterDeployment.Namespace)
+	// PVC not on management cluster — try regional clusters in the namespace
+	regionalCDs, err := common.FindRegionalClusterDeploymentsByRole(ctx, c, namespace)
+	if err != nil {
+		log.Info("Failed to list regional clusters, PVC likely already cleaned up",
+			"PVC.Name", pvcName, "PVC.Namespace", namespace, "error", err)
+		return nil
+	}
+
+	if len(regionalCDs) == 0 {
+		log.Info("No regional clusters found in namespace, PVC does not exist",
+			"PVC.Name", pvcName, "PVC.Namespace", namespace)
+		return nil
+	}
+
+	for i := range regionalCDs {
+		rcd := &regionalCDs[i]
+		regionalClient, err := common.GetRegionalClusterClient(ctx, c, namespace, rcd.Name, scheme)
+		if err != nil {
+			log.Info("Could not create regional cluster client, skipping",
+				"regionalCluster", rcd.Name, "error", err)
+			continue
+		}
+
+		if err := regionalClient.Delete(ctx, pvc); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			log.Error(err, "Failed to delete PVC from regional cluster", "PVC.Name", pvcName, "regionalCluster", rcd.Name)
+			return err
+		}
+
+		log.Info("PVC deleted successfully from regional cluster", "PVC.Name", pvcName, "regionalCluster", rcd.Name)
+		return nil
+	}
+
+	log.Info("PVC not found on any regional cluster", "PVC.Name", pvcName, "PVC.Namespace", namespace)
 	return nil
 }
 
 // WaitForClusterDeletion polls until the given ClusterDeployment is no longer found.
-func WaitForClusterDeletion(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment, colony *infrav1.Colony, scheme *runtime.Scheme, timeout, interval time.Duration) error {
+func WaitForClusterDeletion(ctx context.Context, c client.Client, clusterDeployment *k0rdentv1beta1.ClusterDeployment, scheme *runtime.Scheme, timeout, interval time.Duration) error {
 	log := log.FromContext(ctx)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -457,7 +455,7 @@ func WaitForClusterDeletion(ctx context.Context, c client.Client, clusterDeploym
 				log.Info("ClusterDeployment deleted", "ClusterDeployment.Namespace", clusterDeployment.Namespace, "ClusterDeployment.Name", clusterDeployment.Name)
 
 				// Delete the associated PVC after ClusterDeployment is confirmed deleted
-				if err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme); err != nil {
+				if err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, scheme); err != nil {
 					log.Error(err, "Failed to delete PVC for ClusterDeployment", "ClusterDeployment.Name", clusterDeployment.Name)
 					// Don't return error here as the main deletion was successful
 				}

--- a/internal/controller/infra/clusterdeployment/clusterdeployment_test.go
+++ b/internal/controller/infra/clusterdeployment/clusterdeployment_test.go
@@ -545,7 +545,6 @@ var _ = Describe("EnsureClusterDeployment", func() {
 var _ = Describe("WaitForClusterDeletion", func() {
 	var (
 		scheme            *runtime.Scheme
-		colony            *infrav1.Colony
 		clusterDeployment *k0rdentv1beta1.ClusterDeployment
 		ctx               context.Context
 	)
@@ -553,20 +552,7 @@ var _ = Describe("WaitForClusterDeletion", func() {
 	BeforeEach(func() {
 		scheme = runtime.NewScheme()
 		_ = k0rdentv1beta1.AddToScheme(scheme)
-		_ = infrav1.AddToScheme(scheme)
 		_ = corev1.AddToScheme(scheme)
-
-		colony = &infrav1.Colony{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: "default",
-			},
-			Spec: infrav1.ColonySpec{
-				ColonyClusters: []infrav1.ColonyCluster{
-					{ClusterName: "cluster"},
-				},
-			},
-		}
 
 		clusterDeployment = &k0rdentv1beta1.ClusterDeployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -601,7 +587,7 @@ var _ = Describe("WaitForClusterDeletion", func() {
 			Build()
 
 		// Since ClusterDeployment doesn't exist, the function should immediately detect it's "deleted" and delete the PVC
-		err := WaitForClusterDeletion(ctx, c, clusterDeployment, colony, scheme, 1*time.Second, 100*time.Millisecond)
+		err := WaitForClusterDeletion(ctx, c, clusterDeployment, scheme, 1*time.Second, 100*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify PVC was deleted
@@ -618,7 +604,7 @@ var _ = Describe("WaitForClusterDeletion", func() {
 
 		// Since ClusterDeployment doesn't exist, the function should immediately detect it's "deleted" and try to delete PVC
 		// But since PVC doesn't exist either, it should handle the NotFound error gracefully
-		err := WaitForClusterDeletion(ctx, c, clusterDeployment, colony, scheme, 1*time.Second, 100*time.Millisecond)
+		err := WaitForClusterDeletion(ctx, c, clusterDeployment, scheme, 1*time.Second, 100*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred())
 		// Should not have any additional errors related to PVC deletion
 	})
@@ -656,7 +642,7 @@ var _ = Describe("WaitForClusterDeletion", func() {
 		Expect(c.Create(ctx, pvc)).To(Succeed())
 
 		// Wait for deletion with a short timeout
-		err := WaitForClusterDeletion(ctx, c, clusterDeployment, colony, scheme, 2*time.Second, 50*time.Millisecond)
+		err := WaitForClusterDeletion(ctx, c, clusterDeployment, scheme, 2*time.Second, 50*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Verify PVC was deleted
@@ -1110,15 +1096,97 @@ var _ = Describe("DeletePVCForClusterDeployment", func() {
 		ctx = context.TODO()
 	})
 
-	It("should delete PVC on management cluster for standard (non-regional) cluster", func() {
-		colony := &infrav1.Colony{
+	It("should delete PVC on management cluster when it exists there", func() {
+		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony",
+				Name:      "test-colony-cluster-1",
 				Namespace: "default",
 			},
-			Spec: infrav1.ColonySpec{
-				ColonyClusters: []infrav1.ColonyCluster{
-					{ClusterName: "cluster-1"},
+		}
+
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd-data-kmc-test-colony-cluster-1-etcd-0",
+				Namespace: "default",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(pvc).
+			Build()
+
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify PVC was deleted from management cluster
+		deletedPVC := &corev1.PersistentVolumeClaim{}
+		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-cluster-1-etcd-0", Namespace: "default"}, deletedPVC)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("should return nil gracefully when regional cluster kubeconfig is missing", func() {
+		// Regional CD exists (so it's found by label) but has no kubeconfig secret
+		regionalCD := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dos-lab-regional",
+				Namespace: "default",
+				Labels: map[string]string{
+					common.LabelKOFClusterRole: "regional",
+				},
+			},
+		}
+
+		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-child-1",
+				Namespace: "default",
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(regionalCD).
+			Build()
+
+		// PVC not on management cluster, regional client can't be created — should return nil
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, scheme)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return nil when PVC not found on management cluster and no regional clusters exist", func() {
+		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-colony-cluster-1",
+				Namespace: "default",
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, scheme)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should delete PVC on management cluster even when regional clusters exist", func() {
+		// PVC exists on management cluster — should be deleted there first, not on regional
+		regionalCD := &k0rdentv1beta1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dos-lab-regional",
+				Namespace: "default",
+				Labels: map[string]string{
+					common.LabelKOFClusterRole: "regional",
 				},
 			},
 		}
@@ -1147,178 +1215,15 @@ var _ = Describe("DeletePVCForClusterDeployment", func() {
 
 		c := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(pvc).
-			Build()
-
-		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Verify PVC was deleted from management cluster
-		deletedPVC := &corev1.PersistentVolumeClaim{}
-		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-cluster-1-etcd-0", Namespace: "default"}, deletedPVC)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("not found"))
-	})
-
-	It("should return nil when regional child's kubeconfig secret is not found", func() {
-		// Regional cluster CD must exist so FindRegionalClusterDeployment can find it
-		regionalCD := &k0rdentv1beta1.ClusterDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony-regional-1",
-				Namespace: "default",
-				Labels: map[string]string{
-					common.LabelKOFClusterName: "regional-1",
-				},
-			},
-		}
-
-		colony := &infrav1.Colony{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony",
-				Namespace: "default",
-			},
-			Spec: infrav1.ColonySpec{
-				ColonyClusters: []infrav1.ColonyCluster{
-					{
-						ClusterName: "child-1",
-						ClusterLabels: map[string]string{
-							common.LabelKOFRegionalClusterName: "regional-1",
-						},
-					},
-				},
-			},
-		}
-
-		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony-child-1",
-				Namespace: "default",
-			},
-		}
-
-		c := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(regionalCD).
-			Build()
-
-		// No kubeconfig secret exists for regional cluster — should return nil gracefully
-		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should not delete PVC on management cluster for regional child", func() {
-		// Regional cluster CD exists but no kubeconfig secret
-		regionalCD := &k0rdentv1beta1.ClusterDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony-regional-1",
-				Namespace: "default",
-				Labels: map[string]string{
-					common.LabelKOFClusterName: "regional-1",
-				},
-			},
-		}
-
-		colony := &infrav1.Colony{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony",
-				Namespace: "default",
-			},
-			Spec: infrav1.ColonySpec{
-				ColonyClusters: []infrav1.ColonyCluster{
-					{
-						ClusterName: "child-1",
-						ClusterLabels: map[string]string{
-							common.LabelKOFRegionalClusterName: "regional-1",
-						},
-					},
-				},
-			},
-		}
-
-		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony-child-1",
-				Namespace: "default",
-			},
-		}
-
-		// PVC exists on management cluster — should NOT be deleted since this is a regional child
-		pvc := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "etcd-data-kmc-test-colony-child-1-etcd-0",
-				Namespace: "default",
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
-				},
-			},
-		}
-
-		c := fake.NewClientBuilder().
-			WithScheme(scheme).
 			WithObjects(regionalCD, pvc).
 			Build()
 
-		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
+		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, scheme)
 		Expect(err).NotTo(HaveOccurred())
 
-		// PVC on management cluster should still exist — it was not deleted
-		existingPVC := &corev1.PersistentVolumeClaim{}
-		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-child-1-etcd-0", Namespace: "default"}, existingPVC)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should fall back to management client when no matching ColonyCluster is found", func() {
-		colony := &infrav1.Colony{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony",
-				Namespace: "default",
-			},
-			Spec: infrav1.ColonySpec{
-				ColonyClusters: []infrav1.ColonyCluster{
-					{ClusterName: "cluster-1"},
-				},
-			},
-		}
-
-		// CD name doesn't match any colony-cluster combination
-		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-colony-unknown-cluster",
-				Namespace: "default",
-			},
-		}
-
-		pvc := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "etcd-data-kmc-test-colony-unknown-cluster-etcd-0",
-				Namespace: "default",
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.VolumeResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Gi"),
-					},
-				},
-			},
-		}
-
-		c := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(pvc).
-			Build()
-
-		err := DeletePVCForClusterDeployment(ctx, c, clusterDeployment, colony, scheme)
-		Expect(err).NotTo(HaveOccurred())
-
-		// PVC should be deleted from management cluster (fallback behavior)
+		// PVC should be deleted from management cluster
 		deletedPVC := &corev1.PersistentVolumeClaim{}
-		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-unknown-cluster-etcd-0", Namespace: "default"}, deletedPVC)
+		err = c.Get(ctx, client.ObjectKey{Name: "etcd-data-kmc-test-colony-cluster-1-etcd-0", Namespace: "default"}, deletedPVC)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})

--- a/internal/controller/infra/colony_controller.go
+++ b/internal/controller/infra/colony_controller.go
@@ -431,7 +431,7 @@ func (r *ColonyReconciler) cleanupAssociatedResources(ctx context.Context, colon
 				Namespace: colony.Namespace,
 			},
 		}
-		if err := clusterdeployment.DeletePVCForClusterDeployment(ctx, r.Client, pvcClusterDeployment, colony, r.Scheme); err != nil {
+		if err := clusterdeployment.DeletePVCForClusterDeployment(ctx, r.Client, pvcClusterDeployment, r.Scheme); err != nil {
 			log.Error(err, "Failed to delete PVC for ClusterDeployment", "ClusterDeployment.Name", clusterDeploymentName)
 			// Don't return error here as the main deletion was successful
 		}

--- a/internal/controller/infra/common/regional.go
+++ b/internal/controller/infra/common/regional.go
@@ -81,6 +81,26 @@ func FindRegionalClusterDeployment(ctx context.Context, c client.Client, namespa
 	return &cdList.Items[0], nil
 }
 
+const (
+	// LabelKOFClusterRole is the label on a ClusterDeployment that identifies
+	// the cluster's role. Regional clusters have the value "regional".
+	LabelKOFClusterRole = "k0rdent.mirantis.com/kof-cluster-role"
+)
+
+// FindRegionalClusterDeploymentsByRole finds all regional ClusterDeployments in a namespace
+// by matching the label k0rdent.mirantis.com/kof-cluster-role=regional.
+func FindRegionalClusterDeploymentsByRole(ctx context.Context, c client.Client, namespace string) ([]k0rdentv1beta1.ClusterDeployment, error) {
+	cdList := &k0rdentv1beta1.ClusterDeploymentList{}
+	if err := c.List(ctx, cdList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{LabelKOFClusterRole: "regional"},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list regional ClusterDeployments in namespace %s: %w", namespace, err)
+	}
+
+	return cdList.Items, nil
+}
+
 // GetRegionalClusterClient builds a controller-runtime client for a regional cluster.
 // It fetches the regional cluster's kubeconfig secret from the management cluster
 // and creates a client that can talk to the regional cluster's API server.


### PR DESCRIPTION
## Description
- `DeletePVCForClusterDeployment` previously tried to match the ClusterDeployment back to a `ColonyCluster` in the Colony spec to determine if it was a regional child. This failed for the primary deletion path, when a cluster is removed via     the API, it's already gone from `colony.Spec.ColonyClusters`, so the match never hit and the PVC was only attempted on the management cluster (where it doesn't exist for regional children).
- The function now tries the management cluster first. If the PVC isn't found there, it lists all ClusterDeployments with label `k0rdent.mirantis.com/kof-cluster-role=regional` in the namespace and tries each one. PVC names are unique (contain the CD name), so trying multiple regional clusters is safe.
- Added `FindRegionalClusterDeploymentsByRole()` to the common package and `LabelKOFClusterRole` constant.
- Simplified signatures: `DeletePVCForClusterDeployment` and `WaitForClusterDeletion` no longer need the Colony object.