### PR TITLE
fix: isolate per-cluster ensure failures in colony reconciliation

### DIFF
--- a/internal/controller/infra/clusterdeployment/clusterdeployment.go
+++ b/internal/controller/infra/clusterdeployment/clusterdeployment.go
@@ -134,12 +134,11 @@ func EnsureClusterDeployment(ctx context.Context, c client.Client, colony *infra
 		}
 	}
 	if !exists {
+		// Append the ref in memory only. The Colony status is persisted once at the end
+		// of reconcileColony (a single Status().Patch), so writing it here would be a
+		// redundant patch that races with that final write.
 		colony.Status.ClusterDeploymentRefs = append(colony.Status.ClusterDeploymentRefs, clusterDeploymentRef)
-		if err := updateColonyStatusWithRetry(ctx, c, colony); err != nil {
-			log.Error(err, "Failed to update colony status")
-			return err
-		}
-		log.Info("Updated colony ClusterDeploymentRefs", "name", colony.Name, "namespace", colony.Namespace)
+		log.Info("Added ClusterDeploymentRef to colony status (in-memory)", "name", colony.Name, "namespace", colony.Namespace)
 	}
 
 	return nil
@@ -235,45 +234,6 @@ func updateManagedFields(ctx context.Context, c client.Client,
 	}
 
 	return nil, fmt.Errorf("failed to update ClusterDeployment after %d attempts", maxRetries)
-}
-
-// updateColonyStatusWithRetry handles Colony status updates with conflict resolution
-func updateColonyStatusWithRetry(ctx context.Context, c client.Client, colony *infrav1.Colony) error {
-	log := log.FromContext(ctx)
-	maxRetries := 5
-	backoff := time.Millisecond * 100
-
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		// Get the latest version of the object
-		latest := &infrav1.Colony{}
-		if err := c.Get(ctx, client.ObjectKeyFromObject(colony), latest); err != nil {
-			if errors.IsNotFound(err) {
-				// Object no longer exists, nothing to update
-				return nil
-			}
-			return fmt.Errorf("failed to get latest version of Colony: %w", err)
-		}
-
-		// Update the status with the new ClusterDeploymentRefs
-		latest.Status.ClusterDeploymentRefs = colony.Status.ClusterDeploymentRefs
-
-		// Try to update
-		if err := c.Status().Update(ctx, latest); err != nil {
-			if errors.IsConflict(err) {
-				log.Info("Conflict detected, retrying status update", "attempt", attempt+1, "name", latest.Name)
-				time.Sleep(backoff)
-				backoff *= 2 // Exponential backoff
-				continue
-			}
-			return fmt.Errorf("failed to update Colony status: %w", err)
-		}
-
-		// Update successful, copy the updated object back to colony
-		*colony = *latest
-		return nil
-	}
-
-	return fmt.Errorf("failed to update Colony status after %d attempts due to conflicts", maxRetries)
 }
 
 // CleanupOrphanedClusterDeployments removes ClusterDeployment objects that are no longer

--- a/internal/controller/infra/colony_controller.go
+++ b/internal/controller/infra/colony_controller.go
@@ -19,6 +19,7 @@ package infra
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"time"
@@ -122,18 +123,23 @@ func (r *ColonyReconciler) reconcileColony(ctx context.Context, colony *infrav1.
 		}
 	}
 
-	// Ensure all ClusterDeployments exist
-	for _, colonyCluster := range colony.Spec.ColonyClusters {
-		if colonyCluster.ClusterDeploymentSpec != nil {
-			if err := clusterdeployment.EnsureClusterDeployment(ctx, r.Client, colony, &colonyCluster, r.Scheme); err != nil {
-				log.Error(err, "Failed to ensure cluster deployment")
-				return ctrl.Result{}, err
-			}
+	// Ensure all ClusterDeployments exist. A failure to ensure one cluster must not
+	// block the others, so collect per-cluster errors and keep going. The aggregated
+	// error is returned at the end, after status has been persisted.
+	var clusterErrs []error
+	for i := range colony.Spec.ColonyClusters {
+		colonyCluster := colony.Spec.ColonyClusters[i]
+		if colonyCluster.ClusterDeploymentSpec == nil {
+			continue
+		}
+		if err := clusterdeployment.EnsureClusterDeployment(ctx, r.Client, colony, &colonyCluster, r.Scheme); err != nil {
+			log.Error(err, "Failed to ensure cluster deployment", "cluster", colonyCluster.ClusterName)
+			clusterErrs = append(clusterErrs, fmt.Errorf("cluster %q: %w", colonyCluster.ClusterName, err))
 		}
 	}
 
-	// Update status from cluster states
-	if err := r.updateColonyStatusFromClusters(ctx, colony); err != nil {
+	// Update status from cluster states, surfacing any per-cluster ensure failures.
+	if err := r.updateColonyStatusFromClusters(ctx, colony, clusterErrs); err != nil {
 		log.Error(err, "Failed to update Colony status from clusters")
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 	}
@@ -151,6 +157,14 @@ func (r *ColonyReconciler) reconcileColony(ctx context.Context, colony *infrav1.
 	// 2. The function handles gracefully when services/clusters aren't ready yet
 	// For NetBird-enabled colonies, this is handled by the NetBird reconciler instead
 	r.ensureAPIEndpointConfigMapForAllClusters(ctx, colony)
+
+	// If any cluster failed to be ensured, return the aggregated error now that status
+	// has been persisted and healthy clusters have been serviced. This requeues with
+	// backoff and surfaces in reconcile_errors_total, and takes priority over the
+	// not-all-ready requeue below.
+	if len(clusterErrs) > 0 {
+		return ctrl.Result{}, stderrors.Join(clusterErrs...)
+	}
 
 	// Requeue sooner if not all clusters are ready
 	if colony.Status.ReadyClusters != colony.Status.TotalClusters {
@@ -462,9 +476,8 @@ func (r *ColonyReconciler) cleanupAssociatedResources(ctx context.Context, colon
 // updateColonyStatusFromClusters checks all clusters referenced in the Colony status
 // and updates the Colony status with a ClusterReady condition that is true only if
 // all referenced Clusters have a ready condition.
-func (r *ColonyReconciler) updateColonyStatusFromClusters(ctx context.Context, colony *infrav1.Colony) error {
+func (r *ColonyReconciler) updateColonyStatusFromClusters(ctx context.Context, colony *infrav1.Colony, clusterErrs []error) error {
 	log := log.FromContext(ctx)
-	allReady := true
 	var notReadyClusters []string
 
 	// Log to verify NetBird status is preserved
@@ -473,10 +486,17 @@ func (r *ColonyReconciler) updateColonyStatusFromClusters(ctx context.Context, c
 			"setupKeyID", colony.Status.NetBird.SetupKeyID)
 	}
 
-	// initialize status fields
-	colony.Status.TotalClusters = 0
-	colony.Status.ReadyClusters = 0
+	// Total reflects the intended cluster count from spec, so a cluster that failed to
+	// be ensured (and therefore has no ClusterDeploymentRef) still counts as not-ready
+	// rather than silently disappearing from the totals.
+	totalClusters := 0
+	for i := range colony.Spec.ColonyClusters {
+		if colony.Spec.ColonyClusters[i].ClusterDeploymentSpec != nil {
+			totalClusters++
+		}
+	}
 
+	readyClusters := 0
 	for _, ref := range colony.Status.ClusterDeploymentRefs {
 		clusterDeployment := &k0rdentv1beta1.ClusterDeployment{}
 		key := client.ObjectKey{
@@ -487,40 +507,62 @@ func (r *ColonyReconciler) updateColonyStatusFromClusters(ctx context.Context, c
 			if errors.IsNotFound(err) {
 				log.Info("ClusterDeployment not found", "clusterDeployment", fmt.Sprintf("%s/%s", ref.Namespace, ref.Name))
 				notReadyClusters = append(notReadyClusters, fmt.Sprintf("%s/%s (not found)", ref.Namespace, ref.Name))
-				allReady = false
 				continue
 			}
 			return err
 		}
 
-		clusterDeploymentConditions := clusterDeployment.GetConditions()
-		for _, condition := range *clusterDeploymentConditions {
+		ready := true
+		for _, condition := range *clusterDeployment.GetConditions() {
 			if condition.Type == k0rdentv1beta1.ReadyCondition && condition.Status == metav1.ConditionFalse {
-				allReady = false
-				notReadyClusters = append(notReadyClusters, fmt.Sprintf("%s/%s", ref.Namespace, ref.Name))
+				ready = false
 			}
+		}
+		if ready {
+			readyClusters++
+		} else {
+			notReadyClusters = append(notReadyClusters, fmt.Sprintf("%s/%s", ref.Namespace, ref.Name))
 		}
 	}
 
-	colony.Status.TotalClusters = int32(len(colony.Status.ClusterDeploymentRefs))
-	colony.Status.ReadyClusters = int32(len(colony.Status.ClusterDeploymentRefs) - len(notReadyClusters))
+	// Clusters that could not be ensured at all are not-ready by definition.
+	var failedClusters []string
+	for _, err := range clusterErrs {
+		failedClusters = append(failedClusters, err.Error())
+	}
+
+	colony.Status.TotalClusters = int32(totalClusters)
+	colony.Status.ReadyClusters = int32(readyClusters)
 
 	var condition metav1.Condition
-	if allReady {
-		colony.Status.Phase = "Ready"
+	switch {
+	case len(clusterErrs) > 0:
+		colony.Status.Phase = "Degraded"
+		msg := fmt.Sprintf("%d/%d clusters ready. Failed to ensure: %v", readyClusters, totalClusters, failedClusters)
+		if len(notReadyClusters) > 0 {
+			msg += fmt.Sprintf(". Not ready: %v", notReadyClusters)
+		}
 		condition = metav1.Condition{
 			Type:    "ClustersReady",
-			Status:  metav1.ConditionTrue,
-			Reason:  "AllClustersReady",
-			Message: fmt.Sprintf("All %d clusters of the colony are ready", len(colony.Status.ClusterDeploymentRefs)),
+			Status:  metav1.ConditionFalse,
+			Reason:  "ClusterEnsureFailed",
+			Message: msg,
 		}
-	} else {
+	case readyClusters != totalClusters || len(notReadyClusters) > 0:
 		colony.Status.Phase = "Provisioning"
 		condition = metav1.Condition{
 			Type:    "ClustersReady",
 			Status:  metav1.ConditionFalse,
 			Reason:  "NotAllClustersReady",
-			Message: fmt.Sprintf("%d out of %d clusters are ready. Not ready clusters: %v", colony.Status.ReadyClusters, colony.Status.TotalClusters, notReadyClusters),
+			Message: fmt.Sprintf("%d out of %d clusters are ready. Not ready clusters: %v", readyClusters, totalClusters, notReadyClusters),
+		}
+	default:
+		colony.Status.Phase = "Ready"
+		condition = metav1.Condition{
+			Type:    "ClustersReady",
+			Status:  metav1.ConditionTrue,
+			Reason:  "AllClustersReady",
+			Message: fmt.Sprintf("All %d clusters of the colony are ready", totalClusters),
 		}
 	}
 

--- a/internal/controller/infra/colony_controller.go
+++ b/internal/controller/infra/colony_controller.go
@@ -526,7 +526,7 @@ func (r *ColonyReconciler) updateColonyStatusFromClusters(ctx context.Context, c
 	}
 
 	// Clusters that could not be ensured at all are not-ready by definition.
-	var failedClusters []string
+	failedClusters := make([]string, 0, len(clusterErrs))
 	for _, err := range clusterErrs {
 		failedClusters = append(failedClusters, err.Error())
 	}

--- a/internal/controller/infra/colony_controller_test.go
+++ b/internal/controller/infra/colony_controller_test.go
@@ -25,8 +25,11 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -644,6 +647,86 @@ var _ = Describe("Colony Controller", func() {
 
 		It("getNotReadyReason should return appropriate reasons", func() {
 			Expect(getNotReadyReason(errors.NewNotFound(corev1.Resource("secret"), "test"))).To(Equal("kubeconfig not found"))
+		})
+	})
+
+	Context("Per-cluster failure isolation", func() {
+		// Uses a fake client with an interceptor to deny Create for exactly one cluster's
+		// ClusterDeployment. envtest has no k0rdent admission webhook, so this is the only
+		// way to deterministically reproduce a per-cluster ensure failure.
+		makeCluster := func(name string) infrav1.ColonyCluster {
+			cc := infrav1.ColonyCluster{ClusterName: name}
+			Expect(cc.SetClusterDeploymentSpec(&k0rdentv1beta1.ClusterDeploymentSpec{
+				Template:   "test-template",
+				Credential: "test-credential",
+			})).To(Succeed())
+			return cc
+		}
+
+		It("continues past a failing cluster, reports Degraded, and returns an aggregated error", func() {
+			By("Building a colony with one healthy and one failing cluster")
+			colony := &infrav1.Colony{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "iso-test",
+					Namespace:  "default",
+					UID:        "iso-test-uid",
+					Finalizers: []string{colonyFinalizer},
+				},
+				Spec: infrav1.ColonySpec{
+					ColonyClusters: []infrav1.ColonyCluster{
+						makeCluster("good"),
+						makeCluster("bad"),
+					},
+				},
+			}
+
+			By("Creating a fake client that denies Create for the bad cluster's ClusterDeployment")
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(k8sClient.Scheme()).
+				WithStatusSubresource(&infrav1.Colony{}).
+				WithObjects(colony).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						if cd, ok := obj.(*k0rdentv1beta1.ClusterDeployment); ok && cd.Name == "iso-test-bad" {
+							return errors.NewBadRequest("simulated admission denial: Credential test-credential not found")
+						}
+						return c.Create(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			reconciler := &ColonyReconciler{Client: fakeClient, Scheme: fakeClient.Scheme()}
+
+			By("Reconciling once")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "iso-test", Namespace: "default"},
+			})
+
+			By("Returning the aggregated per-cluster error")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`cluster "bad"`))
+
+			By("Still creating the healthy cluster's ClusterDeployment (sibling not starved)")
+			goodCD := &k0rdentv1beta1.ClusterDeployment{}
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "iso-test-good", Namespace: "default"}, goodCD)).To(Succeed())
+
+			By("Not creating the failing cluster's ClusterDeployment")
+			badCD := &k0rdentv1beta1.ClusterDeployment{}
+			Expect(errors.IsNotFound(fakeClient.Get(ctx, types.NamespacedName{Name: "iso-test-bad", Namespace: "default"}, badCD))).To(BeTrue())
+
+			By("Reporting Degraded status with honest counts")
+			updated := &infrav1.Colony{}
+			Expect(fakeClient.Get(ctx, types.NamespacedName{Name: "iso-test", Namespace: "default"}, updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal("Degraded"))
+			Expect(updated.Status.TotalClusters).To(Equal(int32(2)))
+			Expect(updated.Status.ReadyClusters).To(Equal(int32(1)))
+
+			By("Naming the failed cluster in the ClustersReady condition")
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "ClustersReady")
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("ClusterEnsureFailed"))
+			Expect(cond.Message).To(ContainSubstring(`cluster "bad"`))
 		})
 	})
 })


### PR DESCRIPTION
## Description
A single failing cluster used to take down the whole colony. `reconcileColony` returned on the first `EnsureClusterDeployment` error, so one misconfigured member (e.g. a missing credential) starved its siblings and froze the colony at a stale `Ready` — the failed cluster simply vanished from the status counts.

This isolates failures per cluster: the loop now collects errors and keeps going, reports an honest `Degraded` status, and returns the aggregated error only after status has been persisted.

## Notes for Reviewers

<!-- 
## PR Title Format (Conventional Commits)

Please use one of the following prefixes in your PR title (the scope is optional):

- `feat(scope): ...` – New features or significant enhancements
- `fix(scope): ...` – Bug fixes
- `docs(scope): ...` – Documentation changes
- `refactor(scope): ...` – Code changes that neither fix bugs nor add features
- `chore(scope): ...` – Maintenance tasks, dependency updates, etc.
- `test(scope): ...` – Adding or modifying tests
- `ci(scope): ...` – Changes to CI configuration files and scripts

**Example:** `feat(auth): add OAuth2 login support`

Please also aim to use Conventional Commits for your individual commits, or squash your commits before merging.  
The **CHANGELOG is automatically generated** based on `feat:` and `fix:` messages.

## Multiple Contributors?

If this PR includes commits from multiple authors and you're going to squash-merge it, please consider adding  
`Co-authored-by:` lines to the final squash commit message to give proper credit.

Example:

```
Co-authored-by: Alice <alice@example.com>
Co-authored-by: Bob <bob@example.com>
```

More information: Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-->